### PR TITLE
Fix changelog parsing on Windows systems

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -168,7 +168,7 @@ task publishModrinth(type: TaskModrinthUpload) {
     versionType = isMCVersionNonRelease() ? VersionType.BETA : VersionType.RELEASE
 
     // Changelog fetching
-    def changelogText = file('CHANGELOG.md').text
+    def changelogText = file('CHANGELOG.md').text.replaceAll('\\r\\n', '\n')
     def regexVersion = ((String) project.mod_version).replaceAll('\\.', /\\./).replaceAll('\\+', '\\+')
     def changelogRegex = ~"###? ${regexVersion}\\n\\n(( *- .+\\n)+)"
     def matcher = changelogText =~ changelogRegex


### PR DESCRIPTION
The changelog regex uses `\\n`, which doesn't work with CRLF line endings. This PR just adds a replaceAll call to convert the file to LF before parsing.