### PR TITLE
Improve chunk build performance by caching hasBetterLayer

### DIFF
--- a/src/main/java/dev/lambdaurora/lambdabettergrass/LBGConfig.java
+++ b/src/main/java/dev/lambdaurora/lambdabettergrass/LBGConfig.java
@@ -97,7 +97,7 @@ public class LBGConfig {
      * @param betterSnow {@code true} if better snow is enabled, otherwise {@code false}
      */
     public void setBetterLayer(boolean betterSnow) {
-    	this.betterLayer = betterSnow;
+        this.betterLayer = betterSnow;
         this.config.set("better_layer", betterSnow);
     }
 

--- a/src/main/java/dev/lambdaurora/lambdabettergrass/LBGConfig.java
+++ b/src/main/java/dev/lambdaurora/lambdabettergrass/LBGConfig.java
@@ -32,6 +32,7 @@ public class LBGConfig {
     protected final FileConfig config;
     private final LambdaBetterGrass mod;
     private LBGMode mode;
+    private boolean betterLayer;
 
     public LBGConfig(@NotNull LambdaBetterGrass mod) {
         this.mod = mod;
@@ -50,6 +51,7 @@ public class LBGConfig {
         this.config.load();
 
         this.mode = LBGMode.byId(this.config.getOrElse("mode", DEFAULT_MODE.getName())).orElse(DEFAULT_MODE);
+        this.betterLayer = this.config.getOrElse("better_layer", DEFAULT_BETTER_LAYER);
 
         this.mod.log("Configuration loaded.");
     }
@@ -86,7 +88,7 @@ public class LBGConfig {
      * @return {@code true} if better snow is enabled, otherwise {@code false}
      */
     public boolean hasBetterLayer() {
-        return this.config.getOrElse("better_layer", DEFAULT_BETTER_LAYER);
+        return this.betterLayer;
     }
 
     /**
@@ -95,6 +97,7 @@ public class LBGConfig {
      * @param betterSnow {@code true} if better snow is enabled, otherwise {@code false}
      */
     public void setBetterLayer(boolean betterSnow) {
+    	this.betterLayer = betterSnow;
         this.config.set("better_layer", betterSnow);
     }
 


### PR DESCRIPTION
NightConfig is surprisingly slow at looking up config values, and `hasBetterLayer()` is called several times in baked model rendering, so this improves performance somewhat.